### PR TITLE
Add C3 paper entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ TO BE ADDED
 | ReMA | ✓ | ✓ | MAMRP | [Paper](https://arxiv.org/abs/2503.09501) | [Code](https://github.com/ziyuwan/ReMA-public) |
 | FlowReasoner | ✓ | ✓ | GRPO | [Paper](https://arxiv.org/abs/2504.15257) | [Code](https://github.com/sail-sg/FlowReasoner) |
 | LERO | ✓ | ✓ | MLPO | [Paper](https://arxiv.org/abs/2503.21807) | - |
+| C3 | ✗ | ✓ | PPO / MAPPO / MAGRPO | [Paper](https://arxiv.org/abs/2603.06859) | [Code](https://github.com/EIT-EAST-Lab/C3) [Website](https://eit-east-lab.github.io/C3/) |
 | CURE | ✗ | ✓ | rule-based RL | [Paper](https://arxiv.org/abs/2506.03136) | [Code](https://github.com/Gen-Verse/CURE) [Model](https://huggingface.co/collections/Gen-Verse/reasonflux-coder-6833109ed9300c62deb32c6b) |
 | MMedAgent-RL | ✗ | ✓ | GRPO | [Paper](https://arxiv.org/abs/2506.00555) | - |
 | OWL |  ✓ | ✓ | DPO | [Paper](https://arxiv.org/abs/2505.23885) | [Code](https://github.com/camel-ai/owl) |


### PR DESCRIPTION
## Summary
- add the C3 paper to the RL in Multi-Agent Systems table
- include paper, code, and project page resources

Paper: https://arxiv.org/abs/2603.06859
Code: https://github.com/EIT-EAST-Lab/C3
Project Page: https://eit-east-lab.github.io/C3/